### PR TITLE
Add source of new package imported in this new version of demo

### DIFF
--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -31,6 +31,8 @@ from openvino.inference_engine import IECore
 
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'common'))
 import monitors
+# 'monitors' is a local cpp-library, it can be built with cpp demos via "build_demos.sh" or "build_demos_msvc.bat"
+#  script in demos dir.
 
 
 logging.basicConfig(format="[ %(levelname)s ] %(message)s", level=logging.INFO, stream=sys.stdout)


### PR DESCRIPTION
In regard of the discussion in the issue #1171 (as in the comment (by eizamaliev)[https://github.com/opencv/open_model_zoo/issues/1171#issuecomment-637610746]) the package `monitors` is new package imported in this new version of the demo file. As it is a Cpp resource, it is probable for new users to mistaken it as a conventional PyPi package. Hence, the note helps them install it.